### PR TITLE
Adding a timestamp for 3/2 to each ACF json field so it will show up …

### DIFF
--- a/acf-json/group_584ffb92332be.json
+++ b/acf-json/group_584ffb92332be.json
@@ -509,5 +509,6 @@
     "acfe_permissions": "",
     "acfe_form": 0,
     "acfe_meta": "",
-    "acfe_note": ""
+    "acfe_note": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_58542a93705b1.json
+++ b/acf-json/group_58542a93705b1.json
@@ -61,5 +61,6 @@
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
-    "description": ""
+    "description": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_58584cced2428.json
+++ b/acf-json/group_58584cced2428.json
@@ -567,5 +567,6 @@
     "acfe_permissions": "",
     "acfe_form": 0,
     "acfe_meta": "",
-    "acfe_note": ""
+    "acfe_note": "",
+	"modified": 1614696417
   }

--- a/acf-json/group_5859fb1f56ed1.json
+++ b/acf-json/group_5859fb1f56ed1.json
@@ -38,5 +38,6 @@
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
-    "description": ""
+    "description": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_5878d79c8f654.json
+++ b/acf-json/group_5878d79c8f654.json
@@ -81,5 +81,6 @@
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
-    "description": ""
+    "description": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_588b4f64af2c5.json
+++ b/acf-json/group_588b4f64af2c5.json
@@ -157,5 +157,6 @@
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
-    "description": ""
+    "description": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_589263e2539a9.json
+++ b/acf-json/group_589263e2539a9.json
@@ -38,5 +38,6 @@
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
-    "description": ""
+    "description": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_58a7562977c2e.json
+++ b/acf-json/group_58a7562977c2e.json
@@ -57,5 +57,6 @@
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
-    "description": ""
+    "description": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_58d3f38c525b8.json
+++ b/acf-json/group_58d3f38c525b8.json
@@ -38,5 +38,6 @@
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
-    "description": ""
+    "description": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_59fa07ec9f1eb.json
+++ b/acf-json/group_59fa07ec9f1eb.json
@@ -702,5 +702,6 @@
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
-    "description": ""
+    "description": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_5a74f069a80f9.json
+++ b/acf-json/group_5a74f069a80f9.json
@@ -231,5 +231,6 @@
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
-    "description": ""
+    "description": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_5a95be25a6191.json
+++ b/acf-json/group_5a95be25a6191.json
@@ -902,5 +902,6 @@
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
-    "description": ""
+    "description": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_5c8baaaa68ab8.json
+++ b/acf-json/group_5c8baaaa68ab8.json
@@ -74,5 +74,6 @@
     "acfe_permissions": "",
     "acfe_form": 0,
     "acfe_meta": "",
-    "acfe_note": ""
+    "acfe_note": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_5d25f76223fca.json
+++ b/acf-json/group_5d25f76223fca.json
@@ -43,5 +43,6 @@
         "instruction_placement": "label",
         "hide_on_screen": "",
         "active": true,
-        "description": ""
+        "description": "",
+	"modified": 1614696417
     }

--- a/acf-json/group_5d3f33236e677.json
+++ b/acf-json/group_5d3f33236e677.json
@@ -38,5 +38,6 @@
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
-    "description": ""
+    "description": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_5d9b983e82e4e.json
+++ b/acf-json/group_5d9b983e82e4e.json
@@ -149,5 +149,6 @@
     "acfe_permissions": "",
     "acfe_form": 0,
     "acfe_meta": "",
-    "acfe_note": ""
+    "acfe_note": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_5d9f36a7a9fdd.json
+++ b/acf-json/group_5d9f36a7a9fdd.json
@@ -633,5 +633,6 @@
     "acfe_autosync": "",
     "acfe_form": 0,
     "acfe_meta": "",
-    "acfe_note": ""
+    "acfe_note": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_5e1392f0b310c.json
+++ b/acf-json/group_5e1392f0b310c.json
@@ -145,5 +145,6 @@
     "instruction_placement": "label",
     "hide_on_screen": "",
     "active": true,
-    "description": ""
+    "description": "",
+	"modified": 1614696417
 }

--- a/acf-json/group_5e1dfe7b3f1ed.json
+++ b/acf-json/group_5e1dfe7b3f1ed.json
@@ -485,9 +485,6 @@
     "active": true,
     "description": "",
     "acfe_display_title": "",
-    "acfe_autosync": [
-        "json"
-    ],
     "acfe_form": 0,
     "acfe_meta": "",
     "acfe_note": "",

--- a/acf-json/group_5e540a3f5a7de.json
+++ b/acf-json/group_5e540a3f5a7de.json
@@ -6488,5 +6488,6 @@
   "acfe_autosync": "",
   "acfe_form": 0,
   "acfe_meta": "",
-  "acfe_note": ""
+  "acfe_note": "",
+  "modified": 1614696417
 }

--- a/acf-json/group_5e7367b292754.json
+++ b/acf-json/group_5e7367b292754.json
@@ -73,5 +73,6 @@
   "acfe_autosync": "",
   "acfe_form": 0,
   "acfe_meta": "",
-  "acfe_note": ""
+  "acfe_note": "",
+  "modified": 1614696417
 }


### PR DESCRIPTION
…as sync-able on the live site. This was needed because they were exported without a modified timestamp so they did not show up as able to sync with the main site. This means that they were being loaded from JSON but maybe weren't the most up to date. 